### PR TITLE
Add description arg in lane

### DIFF
--- a/fastlane-plugin-github_job_status/README.md
+++ b/fastlane-plugin-github_job_status/README.md
@@ -24,6 +24,7 @@ github_job_status(
   repo: 'fastlane_plugins',
   sha: 'commit_sha',
   job_name: 'good_job',
+  description: 'A short description',
   build_url: 'skullcrushers.gov',
   state: 'pending'
 )
@@ -31,7 +32,7 @@ github_job_status(
 
  * `state` must be pending, success, error, or failure
  * `token` can be obtained in GitHub for an owner (To do this, go to settings/Personal access tokens. Generate a new token and be sure to enable `repo:status`.)
- * `job_name` and  `build_url` are optional, but all other parameters are required
+ * `job_name`, `description` and `build_url` are optional, but all other parameters are required
 
 ## Example
 

--- a/fastlane-plugin-github_job_status/lib/fastlane/plugin/github_job_status/actions/github_job_status_action.rb
+++ b/fastlane-plugin-github_job_status/lib/fastlane/plugin/github_job_status/actions/github_job_status_action.rb
@@ -22,6 +22,8 @@ module Fastlane
         payload['context'] = context unless context.nil?
         target_url = params[:build_url]
         payload['target_url'] = target_url unless target_url.nil?
+        description = params[:description]
+        payload['description'] = description unless description.nil?
 
         begin
           post(url, payload.to_json, headers)
@@ -112,6 +114,12 @@ module Fastlane
                 UI.user_error! "Invalid state '#{value}' given. State must be pending, success, error, or failure."
               end
             end
+          ),
+          FastlaneCore::ConfigItem.new(
+            key: :description,
+            env_name: 'GITHUB_JOB_STATUS_DESCRIPTION',
+            description: 'The string displayed after job name',
+            optional: true
           )
         ]
       end

--- a/fastlane-plugin-github_job_status/spec/github_job_status_action_spec.rb
+++ b/fastlane-plugin-github_job_status/spec/github_job_status_action_spec.rb
@@ -25,6 +25,7 @@ describe Fastlane::Actions::GithubJobStatusAction do
         repo: 'fastlane_plugins',
         sha: 'commit_sha',
         job_name: 'good_job',
+        description: 'A short description',
         build_url: 'skullcrushers.gov',
         state: 'pending'
       )


### PR DESCRIPTION
Add support for Github API field : `description`.

Issue https://github.com/justinsinger/fastlane_plugins/issues/1.