### PR TITLE
Add `description` field

### DIFF
--- a/fastlane-plugin-github_job_status/README.md
+++ b/fastlane-plugin-github_job_status/README.md
@@ -24,6 +24,7 @@ github_job_status(
   repo: 'fastlane_plugins',
   sha: 'commit_sha',
   job_name: 'good_job',
+  description: 'A short description',
   build_url: 'skullcrushers.gov',
   state: 'pending'
 )
@@ -31,7 +32,7 @@ github_job_status(
 
  * `state` must be pending, success, error, or failure
  * `token` can be obtained in GitHub for an owner (To do this, go to settings/Personal access tokens. Generate a new token and be sure to enable `repo:status`.)
- * `job_name` and  `build_url` are optional, but all other parameters are required
+ * `job_name`, `description` and `build_url` are optional, but all other parameters are required
 
 ## Example
 

--- a/fastlane-plugin-github_job_status/lib/fastlane/plugin/github_job_status/actions/github_job_status_action.rb
+++ b/fastlane-plugin-github_job_status/lib/fastlane/plugin/github_job_status/actions/github_job_status_action.rb
@@ -16,7 +16,7 @@ module Fastlane
 
         payload = {
           state: params[:state],
-          description: description_for_state(params[:state])
+          description: !params[:description] ? description_for_state(params[:state]) : params[:description]
         }
         context = params[:job_name]
         payload['context'] = context unless context.nil?
@@ -95,6 +95,12 @@ module Fastlane
             key: :job_name,
             env_name: 'GITHUB_JOB_STATUS_JOB_NAME',
             description: 'The string displayed next to the status indicator but before the description',
+            optional: true
+          ),
+          FastlaneCore::ConfigItem.new(
+            key: :description,
+            env_name: 'GITHUB_JOB_STATUS_DESCRIPTION',
+            description: 'The string displayed after job name',
             optional: true
           ),
           FastlaneCore::ConfigItem.new(

--- a/fastlane-plugin-github_job_status/spec/github_job_status_action_spec.rb
+++ b/fastlane-plugin-github_job_status/spec/github_job_status_action_spec.rb
@@ -1,33 +1,61 @@
 require 'fastlane'
 
 describe Fastlane::Actions::GithubJobStatusAction do
+  before :all do
+    @url = "https://api.github.com/repos/justinsinger/fastlane_plugins/statuses/commit_sha"
+    @headers = {
+      'Authorization' => "token github_token",
+      'User-Agent' => 'fastlane',
+      'content_type' => :json,
+      'accept' => :json
+    }
+  end
+
   describe 'given all valid parameters' do
-    it 'posts a valid status' do
-      url = "https://api.github.com/repos/justinsinger/fastlane_plugins/statuses/commit_sha"
-      headers = {
-        'Authorization' => "token github_token",
-        'User-Agent' => 'fastlane',
-        'content_type' => :json,
-        'accept' => :json
-      }
-      payload = {
-        state: 'pending',
-        description: 'Job pending',
-        context: 'good_job',
-        target_url: 'skullcrushers.gov'
-      }
+    context 'with default description' do
+      it 'posts a valid status' do
+        payload = {
+          state: 'pending',
+          description: 'Job pending',
+          context: 'good_job',
+          target_url: 'skullcrushers.gov'
+        }
 
-      expect(Fastlane::Actions::GithubJobStatusAction).to receive(:post).with(url, payload.to_json, headers)
+        expect(Fastlane::Actions::GithubJobStatusAction).to receive(:post).with(@url, payload.to_json, @headers)
 
-      Fastlane::Actions::GithubJobStatusAction.run(
-        token: 'github_token',
-        owner: 'justinsinger',
-        repo: 'fastlane_plugins',
-        sha: 'commit_sha',
-        job_name: 'good_job',
-        build_url: 'skullcrushers.gov',
-        state: 'pending'
-      )
+        Fastlane::Actions::GithubJobStatusAction.run(
+          token: 'github_token',
+          owner: 'justinsinger',
+          repo: 'fastlane_plugins',
+          sha: 'commit_sha',
+          job_name: 'good_job',
+          build_url: 'skullcrushers.gov',
+          state: 'pending'
+        )
+      end
+    end
+    context 'with a given description' do
+      it 'posts a valid status' do
+        payload = {
+          state: 'success',
+          description: 'A very short description',
+          context: 'good_job',
+          target_url: 'skullcrushers.gov'
+        }
+
+        expect(Fastlane::Actions::GithubJobStatusAction).to receive(:post).with(@url, payload.to_json, @headers)
+
+        Fastlane::Actions::GithubJobStatusAction.run(
+          token: 'github_token',
+          owner: 'justinsinger',
+          repo: 'fastlane_plugins',
+          sha: 'commit_sha',
+          job_name: 'good_job',
+          description: 'A very short description',
+          build_url: 'skullcrushers.gov',
+          state: 'success'
+        )
+      end
     end
   end
 


### PR DESCRIPTION
Add availability to custom `description` field as described in [Github Status API](https://developer.github.com/v3/repos/statuses/).

Issue : https://github.com/justinsinger/fastlane_plugins/issues/1